### PR TITLE
do not submit jobs and alert when there is no classroom available

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -44,8 +44,8 @@ attributes:
       * **medium** - 2 cores & 8 GB of memory.
       * **large** - 4 cores & 16 GB of memory.
       * **extra-large** - 8 cores & 32 GB of memory.
+  classroom:
   <%- if classrooms.size >= 1 -%>
-  classroom:  
     widget: select
     options:
       <%- classrooms.each do |key, value| %>
@@ -54,4 +54,7 @@ attributes:
         data-set-account: "<%= value %>"
         ]
       <%- end %>
+  <%- else -%>
+    widget: 'hidden_field'
+    value: 'no_classroom'
   <%- end -%>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,4 +1,11 @@
 <%
+  err_msg = "You are not a part of any classroom project. Restarting your web \
+    server in the help menu may fix the issue. You may also have to wait if you've \
+    recently been added to the project. Reach out to your instructor or \
+    contact support through the help menu."
+
+  raise StandardError, err_msg  if classroom == 'no_classroom'
+
   mounts = {
     'home'    => OodSupport::User.new.home,
     'support' => OodSupport::User.new('support').home,


### PR DESCRIPTION
do not submit jobs and alert when there is no classroom available.

This is for the case when you're not actually in a classroom, like you're enrolled in Jupyter classes and just happen to navigate to RStudio. The alert looks like this:

![image](https://user-images.githubusercontent.com/4874123/144303421-2aba5611-4858-4d3c-862b-a32403893aa3.png)
