### PR TITLE
categories are case sensitive

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 name: Classroom RStudio
 category: Interactive Apps
-subcategory: classroom
+subcategory: Classrooms
 role: batch_connect
 description: |
   This app will launch [RStudio Server] server for use in a classroom.


### PR DESCRIPTION
categories are case sensitive, so let's capitalize this and pluralize so it looks just a little nicer.