### PR TITLE
remove duplicate size entry in form

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -59,28 +59,6 @@ attributes:
   size:
     widget: "select"
     options:
-      - [ "1.5 hours", "1.5"]
-      - [
-          "3 hours", "3",
-          <%- classrooms.each do |cr| %>
-            <%- unless cr[:time].to_i >= 3 %>
-            data-option-for-classroom-<%= cr[:name].to_s.gsub('_', '-') %>: false,
-            <%- end %>
-          <%- end %>
-        ]
-      - [
-          "6 hours", "6",
-          <%- classrooms.each do |cr| %>
-            <%- unless cr[:time].to_i >= 6 %>
-            data-option-for-classroom-<%= cr[:name].to_s.gsub('_', '-') %>: false,
-            <%- end %>
-          <%- end %>
-        ]
-    required: true
-    help: Instructors can request longer times.
-  size:
-    widget: "select"
-    options:
       - [
           "small", "small",
         ]


### PR DESCRIPTION
remove duplicate size entry in form. Luckily the correct one was defined second.