### PR TITLE
pod using the wrong name

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -42,7 +42,7 @@ script:
   wall_time: "<%= time.to_f * 3600 %>"
   native:
     container:
-      name: "jupyter"
+      name: "rstudio"
       image: "docker-registry.osc.edu/ondemand/ondemand-base-rhel7:0.4.0"
       image_pull_policy: "IfNotPresent"
       command: ["/bin/bash","-l","<%= staged_root %>/job_script_content.sh"]


### PR DESCRIPTION
Rstudio pods are using the wrong name. @treydock FYI in case you're keeping track of Jupyter vs Rstudio classes.