### PR TITLE
use generic R versioned modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.0] - 2022-06-03
+
+### Changed
+
+- Use a generic module instead of classroom specific modules in [16](https://github.com/OSC/bc_classroom_rstudio/pull/16).
+
 ## [0.3.0] - 2022-01-13
 
 ### Changed
@@ -31,7 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.1.0...v0.2.0

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -112,7 +112,7 @@ attributes:
         "<%= cr[:name].gsub('_', ' ') %>", "<%= cr[:name] %>",
         data-set-account: "<%= cr[:account] %>",
         data-set-compute-cluster: "<%= cr[:compute_cluster] %>",
-        data-set-module-type: "<%= cr[:r_version] %>"
+        data-set-r-version: "<%= cr[:r_version] %>"
         ]
       <%- end %>
   <%- else -%>

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -17,6 +17,7 @@
       size: tokens[1].nil? ? 1 : tokens[1].to_i,
       time: tokens[2].nil? ? 1 : tokens[2].to_i,
       compute_cluster: tokens[3].nil? ? 'pitzer' : tokens[3].to_s,
+      r_version: tokens[4].nil? ? '4.0.2' : tokens[4].to_s,
       account: v,
     }
   end
@@ -32,10 +33,13 @@ form:
   - size
   - time
   - compute_cluster
+  - r_version
 attributes:
   account:
     widget: "hidden_field"
   compute_cluster:
+    widget: "hidden_field"
+  r_version:
     widget: "hidden_field"
   time:
     widget: "select"
@@ -107,7 +111,8 @@ attributes:
       - [
         "<%= cr[:name].gsub('_', ' ') %>", "<%= cr[:name] %>",
         data-set-account: "<%= cr[:account] %>",
-        data-set-compute-cluster: "<%= cr[:compute_cluster] %>"
+        data-set-compute-cluster: "<%= cr[:compute_cluster] %>",
+        data-set-module-type: "<%= cr[:r_version] %>"
         ]
       <%- end %>
   <%- else -%>

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -2,8 +2,10 @@
 
 module purge
 
-module purge
-module load project/classroom xalt/latest rstudio/<%= context.classroom %>
+export OSC_CLASS_ID="<%= context.classroom %>"
+export OSC_PROJECT_ID="<%= context.account %>"
+
+module load project/classroom xalt/latest classroom_rstudio/<%= context.r_version %>
 
 #
 # Start RStudio Server


### PR DESCRIPTION
use generic modules that rely on `OSC_CLASS_ID` and `OSC_PROJECT_ID` environment variables to load the classroom instead of using specific modules for each and every classroom.