### PR TITLE
add support for R/4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2022-09-27
+
+- Added support for R 4.1.0 in [19](https://github.com/OSC/bc_classroom_rstudio/pull/19).
+
 ## [0.4.1] - 2022-09-15
 
 ### Changed
@@ -43,7 +47,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/OSC/bc_classroom_rstudio/compare/v0.2.1...v0.3.0

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -37,6 +37,10 @@
   apps_path = compute_cluster == 'pitzer' ? '/apps' : '/usr/local'
 -%>
 ---
+batch_connect:
+  template: "basic"
+  conn_params:
+    - csrf_token
 script:
   accounting_id: "<%= account %>"
   wall_time: "<%= time.to_f * 3600 %>"
@@ -102,3 +106,28 @@ script:
         host_type: Directory
         path: "/apps/<%= compute_cluster %>"
         destination_path: "<%= apps_path %>"
+    configmap:
+      files:
+        - filename: "logging.conf"
+          data: |
+            [*]
+            log-level=debug
+            logger-type=file
+            log-dir=<%= staged_root %>/logs
+          mount_path: '/etc/rstudio'
+        - filename: "database.conf"
+          data: |
+            directory=/tmp/lib/rstudio-server
+          mount_path: '/etc/rstudio/database'
+        - filename: 'k8_helper'
+          data: |
+            #!/usr/bin/env bash
+
+            set -x
+
+            KEY=$1
+            VALUE=$(echo -n $2 | base64)
+            CFG="$(hostname)-secret"
+
+            kubectl get secret ${CFG} -o json | jq --arg key $KEY --arg value $VALUE '.data[$key] = $value'  | kubectl apply -f -
+          mount_path: '/opt/open_ondemand/helpers'

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -9,7 +9,13 @@ source /bin/save_passwd_as_secret
 password="$PASSWORD"
 host="$HOST_CFG"
 port="$PORT_CFG"
-export SINGULARITY_HOME="$HOME"
 
+# rstudio 1.4+ needs a csrf token
+csrf_token=<%= SecureRandom.uuid %>
+echo "password is: $password"
+
+/bin/bash /opt/open_ondemand/helpers/k8_helper csrf_token "$csrf_token"
+
+export SINGULARITY_HOME="$HOME"
 export RSTUDIO_PASSWORD="${password}"
 

--- a/template/bin/auth
+++ b/template/bin/auth
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Confirm username is supplied
-if [[ $# -ne 1 ]]; then
+if [[ $# -lt 1 ]]; then
   echo "Usage: auth USERNAME"
   exit 1
 fi

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -53,7 +53,7 @@ sed 's/^ \{2\}//' > "$WORKING_DIR/rsession.sh" << EOL
 EOL
 )
 chmod 700 "$WORKING_DIR/rsession.sh"
-
+mkdir -p "$WORKING_DIR/logs"
 
 # Output debug info
 module list
@@ -68,4 +68,9 @@ rserver \
   --auth-none 0 \
   --auth-pam-helper-path "${RSTUDIO_AUTH}" \
   --auth-encrypt-password 0 \
-  --rsession-path "${RSESSION_WRAPPER_FILE}"
+  --rsession-path "${RSESSION_WRAPPER_FILE}" \
+  <%- if version > '4.1' -%>
+  --database-config-file='/etc/rstudio/database/database.conf' \
+  --server-data-dir='/tmp/run' \
+  --server-user=$(whoami)
+  <%- end -%>

--- a/view.html.erb
+++ b/view.html.erb
@@ -1,4 +1,19 @@
+<script type="text/javascript">
+(function () {
+  let date = new Date();
+  date.setTime(date.getTime() + (7*24*60*60*1000));
+  let expires = "expires=" + date.toUTCString();
+  let cookiePath = "path=/rnode/" + "<%= host.to_s %>" + "/" + "<%= port.to_s %>/";
+  /**
+    rstuido wants a cookie called csrf-token - but that's going to change in 2020!
+  */
+  let cookie = `csrf-token=<%= csrf_token %>;${expires};${cookiePath};SameSite=strict;secure`;
+  document.cookie = cookie;
+})();
+</script>
+
 <form action="/rnode/<%= host %>/<%= port %>/auth-do-sign-in" method="post" target="_blank">
+  <input type="hidden" name="csrf-token" value="<%= csrf_token %>"/>
   <input type="hidden" name="username" value="<%= ENV["USER"] %>">
   <input type="hidden" name="password" value="<%= password %>">
   <input type="hidden" name="staySignedIn" value="1">


### PR DESCRIPTION
add support for R/4.1.0. Note that this requires a patch to `ood_core` or a monkey patch to the dashboard so that `csrf_token` is correctly passed back to the dashboard.