### PR TITLE
use a map config and use cluster_fs instead.

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -3,24 +3,30 @@
     groups.unshift(groups.delete(OodSupport::Process.group))
   end.map(&:name).grep(/^P./)
 
-  classrooms = OodAppkit.clusters.each_with_object({}) do |cluster, hash|
-    if cluster.kubernetes?
-      hash.merge!(cluster.custom_config[:classrooms].to_h)
-    end
-  end.select do |k,v|
-    k.start_with?('rstudio') && groups.include?(v)
-  end.map do |k,v|
-    tokens = k.gsub('rstudio/', '').split('/')
+  classrooms = OodAppkit.clusters.map do |cluster|
+    [ cluster.id.to_s, cluster.custom_config[:classrooms].to_h ]
+  end.to_h.map do |cluster_id, classrooms|
+    classes = classrooms.select do |app_type, class_configs|
+      app_type == 'rstudio'
+    end.map do |_app_type, class_configs|
+      class_configs.map do |name, class_config|
 
-    {
-      name: tokens[0].nil? ? 'unknown' : tokens[0],
-      size: tokens[1].nil? ? 1 : tokens[1].to_i,
-      time: tokens[2].nil? ? 1 : tokens[2].to_i,
-      compute_cluster: tokens[3].nil? ? 'pitzer' : tokens[3].to_s,
-      r_version: tokens[4].nil? ? '4.0.2' : tokens[4].to_s,
-      account: v,
-    }
-  end
+        {
+          name: name,
+          size: class_config.fetch('size', 1).to_i,
+          time: class_config.fetch('time', 1).to_i,
+          cluster_fs: class_config.fetch('cluster_fs', 'pitzer'),
+          r_version: class_config.fetch('r_version', '4.0.2'),
+          account: class_config.fetch('project', nil),
+          cluster: cluster_id
+        }
+
+      end.select do |class_config|
+        acct = class_config.fetch(:account, nil)
+        !acct.nil? && groups.include?(acct)
+      end
+    end
+  end.flatten
 -%>
 ---
 cluster:
@@ -32,12 +38,12 @@ form:
   - account
   - size
   - time
-  - compute_cluster
+  - cluster_fs
   - r_version
 attributes:
   account:
     widget: "hidden_field"
-  compute_cluster:
+  cluster_fs:
     widget: "hidden_field"
   r_version:
     widget: "hidden_field"
@@ -111,7 +117,7 @@ attributes:
       - [
         "<%= cr[:name].gsub('_', ' ') %>", "<%= cr[:name] %>",
         data-set-account: "<%= cr[:account] %>",
-        data-set-compute-cluster: "<%= cr[:compute_cluster] %>",
+        data-set-cluster-fs: "<%= cr[:cluster_fs] %>",
         data-set-r-version: "<%= cr[:r_version] %>"
         ]
       <%- end %>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -34,7 +34,7 @@
     },
   }
 
-  apps_path = compute_cluster == 'pitzer' ? '/apps' : '/usr/local'
+  apps_path = cluster_fs == 'pitzer' ? '/apps' : '/usr/local'
 -%>
 ---
 batch_connect:
@@ -94,17 +94,17 @@ script:
       - type: host
         name: lmod-init
         host_type: File
-        path: /apps/<%= compute_cluster %>/lmod/lmod.sh
+        path: /apps/<%= cluster_fs %>/lmod/lmod.sh
         destination_path: /etc/profile.d/lmod.sh
       - type: host
         name: intel
         host_type: Directory
-        path: /nfsroot/<%= compute_cluster %>/opt/intel
+        path: /nfsroot/<%= cluster_fs %>/opt/intel
         destination_path: /opt/intel
       - type: host
         name: apps
         host_type: Directory
-        path: "/apps/<%= compute_cluster %>"
+        path: "/apps/<%= cluster_fs %>"
         destination_path: "<%= apps_path %>"
     configmap:
       files:


### PR DESCRIPTION
This updates to use a map configuration instead of parsing a key. It also standardizes on cluster_fs instead of using compute_cluster (jupyter uses cluster_fs).